### PR TITLE
"Fix" for OSX

### DIFF
--- a/src/level.go
+++ b/src/level.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/go-gl/gl/v2.1/gl"
+	"github.com/go-gl/gl/v4.1-core/gl"
 )
 
 const (
@@ -70,11 +70,11 @@ func getBasicShader() (*Shader, error) {
 			return nil, err
 		}
 
-		err = _basicShader.addProgramFromFile("basicVertex120.vs", gl.VERTEX_SHADER)
+		err = _basicShader.addProgramFromFile("basicVertex.vs", gl.VERTEX_SHADER)
 		if err != nil {
 			return nil, err
 		}
-		err = _basicShader.addProgramFromFile("basicFragment120.fs", gl.FRAGMENT_SHADER)
+		err = _basicShader.addProgramFromFile("basicFragment.fs", gl.FRAGMENT_SHADER)
 		if err != nil {
 			return nil, err
 		}

--- a/src/main.go
+++ b/src/main.go
@@ -25,7 +25,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/go-gl/gl/v2.1/gl"
+	"github.com/go-gl/gl/v4.1-core/gl"
 	"github.com/go-gl/glfw/v3.1/glfw"
 )
 
@@ -84,8 +84,10 @@ under GNU/GPLv2 license.`+"\n", version)
 	defer glfw.Terminate()
 
 	// create a context and activate it
-	glfw.WindowHint(glfw.ContextVersionMajor, 2)
+	glfw.WindowHint(glfw.ContextVersionMajor, 4)
 	glfw.WindowHint(glfw.ContextVersionMinor, 1)
+	glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)
+	glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
 	glfw.WindowHint(glfw.Resizable, glfw.False)
 	glfw.WindowHint(glfw.DoubleBuffer, glfw.True)
 	var err error

--- a/src/mesh.go
+++ b/src/mesh.go
@@ -17,7 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 package main
 
-import "github.com/go-gl/gl/v2.1/gl"
+import "github.com/go-gl/gl/v4.1-core/gl"
 
 type Mesh struct {
 	vbo, ibo uint32

--- a/src/shader.go
+++ b/src/shader.go
@@ -23,7 +23,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/go-gl/gl/v2.1/gl"
+	"github.com/go-gl/gl/v4.1-core/gl"
 )
 
 type Shader struct {
@@ -84,6 +84,10 @@ func (s *Shader) getShaderInfoLog(shader uint32, context string) error {
 }
 
 func (s *Shader) compile() error {
+	var vao uint32
+	gl.GenVertexArrays(1, &vao)
+	gl.BindVertexArray(vao)
+
 	gl.LinkProgram(s.program)
 	var result int32
 	gl.GetProgramiv(s.program, gl.LINK_STATUS, &result)

--- a/src/texture.go
+++ b/src/texture.go
@@ -24,7 +24,7 @@ import (
 	_ "image/png"
 	"os"
 
-	"github.com/go-gl/gl/v2.1/gl"
+	"github.com/go-gl/gl/v4.1-core/gl"
 )
 
 type Texture struct {


### PR DESCRIPTION
I stumbled upon this project and thought it was cool, but noticed an old issue (#4) for incompatibilities with OSX. On a hunch I tried simply upgrading the OpenGL version in case it was a problem with either the go-gl compatibility layer or the underlying c-code itself. It works!

The change is pretty straight forward. Imports are updated from `v2.2` to `v4.1-core`, the file paths for the shaders is updated to use the shader language version `3.3.0` files that were already in the `res/shaders/` folder, and some additional window hints were provided to make OSX happy with the forward compatibility of `4.1`.

The one thing that threw me for a loop was that I was getting unhelpful messages for when compilation of the shaders failed. So, I added better logging output there. At which point, I noticed that for version `4.1` it was complaining about there not being a `vertex array object` bound. So, I just shoehorned these lines

```
var vao uint32
gl.GenVertexArrays(1, &vao)
gl.BindVertexArray(vao)
```

into the compile functon. I have no clue if they make any sense there or not or if they belong elsewhere as I've never touched any of these libs before 30 minutes ago, but it seems to work?

Anyway, I know this was just a toy project but I figured I'd drop this PR for anyone else interested in it or in case you were inclined to take a stab at updating it.

Cool project, either way!